### PR TITLE
Add subscribe lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Any .zip files from building lambdas
+*.zip
+
+# Any built Go files for lambdas or otherwise
+*/main

--- a/lambdas/subscribe/main.go
+++ b/lambdas/subscribe/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// Response from API
+type Response struct {
+	PhoneNumber string `json:"phoneNumber"`
+}
+
+// Request struct - incoming HTTP request
+type Request struct {
+	PhoneNumber string `json:"phoneNumber"`
+}
+
+// Handler function for lambda
+func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	//				START MONGODB SETUP					//
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(
+		os.Getenv("MONGODB_URI"),
+	))
+	if err != nil {
+		log.Fatal("Connection error:", err)
+		return events.APIGatewayProxyResponse{
+			Body:       err.Error(),
+			StatusCode: 500,
+		}, err
+	}
+
+	defer client.Disconnect(ctx)
+	err = client.Ping(ctx, readpref.Primary())
+	if err != nil {
+		log.Fatal("Ping error:", err)
+		return events.APIGatewayProxyResponse{
+			Body:       err.Error(),
+			StatusCode: 500,
+		}, err
+	}
+
+	coronalertDB := client.Database("Coronalert")
+	phoneNumbersCollection := coronalertDB.Collection("PhoneNumbers")
+	//				END MONGODB SETUP					//
+
+	//				START SUBSCRIBE						//
+	bodyRequest := Request{
+		PhoneNumber: "",
+	}
+
+	err = json.Unmarshal([]byte(request.Body), &bodyRequest)
+	if err != nil {
+		log.Fatal("error in unmarshal")
+		return events.APIGatewayProxyResponse{
+			Body:       err.Error(),
+			StatusCode: 500,
+		}, err
+	}
+
+	_, err = phoneNumbersCollection.InsertOne(ctx, bson.D{
+		{Key: "phoneNumber", Value: bodyRequest.PhoneNumber},
+	})
+	if err != nil {
+		log.Fatal("error adding to collection")
+		return events.APIGatewayProxyResponse{
+			Body:       err.Error(),
+			StatusCode: 500,
+		}, err
+	}
+
+	bodyResponse := Response{
+		PhoneNumber: bodyRequest.PhoneNumber,
+	}
+
+	response, err := json.Marshal(&bodyResponse)
+	if err != nil {
+		log.Fatal("error in marshal")
+		return events.APIGatewayProxyResponse{
+			Body:       err.Error(),
+			StatusCode: 500,
+		}, err
+	}
+	//				END SUBSCRIBE						//
+
+	return events.APIGatewayProxyResponse{
+		Body:       string(response),
+		StatusCode: 200,
+	}, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}


### PR DESCRIPTION
- Adds a lambda that contains similar subscribe functionality to what we previously had
- On subscribe, request body containing phone number is persisted in MongoDB cluster
- Add .gitignore so we don't accidentally add built go builds or zipped builds when creating lambdas going forward

<img width="840" alt="Screen Shot 2020-04-12 at 5 57 55 PM" src="https://user-images.githubusercontent.com/15767602/79080967-28adf480-7ce7-11ea-99db-3db4ac86b20b.png">