### PR TITLE
Use different seed for every sendSMS lambda run (#41)

### DIFF
--- a/lambdas/sendSMS/main.go
+++ b/lambdas/sendSMS/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 
@@ -129,6 +130,9 @@ func Handler(ctx context.Context) (string, error) {
 	}
 
 	defer cur.Close(ctx)
+
+	// For different seed on every execution
+	rand.Seed(time.Now().UnixNano())
 
 	// For each record, send a notification
 	for cur.Next(ctx) {


### PR DESCRIPTION
# ⚠️ __IMPORTANT: Please do not create a Pull Request without creating an issue first.__

All changes need to be discusssed before proceeding. Failure to do so may result in the pull request being rejected.

Please be sure to review our [Code of Conduct](https://github.com/COVID-19-electronic-health-system/.github/blob/master/CODE_OF_CONDUCT.md), [Contributing Guidelines](https://github.com/COVID-19-electronic-health-system/.github/blob/master/CONTRIBUTING.md), and [Support documentation](https://github.com/COVID-19-electronic-health-system/.github/blob/master/SUPPORT.md) before submitting a pull request.

-----

## Please include the issue number the pull request fixes by replacing YOUR-ISSUE-HERE in the text below.

Fixes #41 

## Summary

The notification sending Lambda will now use a different seed on every execution. This fixes the issue where the same notification was being sent repeatedly.

## Test Plan (required)



<!-- Demonstrate the code is solid, e.g. list the exact commands you ran and their output, and screenshots/video if the pull request modifies the UI. -->

## Final Checklist

- [ ] For CoronaTracker, did you bump the version in `package.json`?
    - Update the second decimal for a major change
    - Update the third decimal for a minor change
    - Numbers can go past 9, e.g. `1.0.9` => `1.0.10`
    - For more info, read about [Semantic Versioning](https://semver.org/)
- [ ] Did you add any new tests as necessary?
- [x] Is your PR rebased off the most current master?
- [x] Have you squashed all commits? _(can be done at merge)_
- [ ] Did you use `yarn` not `npm`? _(important!)_
- [ ] Did you use Material-UI wherever possible?
- [ ] Did you run `yarn lint` on the code?
- [x] Did you run all of your most recent changes locally to make sure everything is working?
